### PR TITLE
Python 3 support in build_html_iframe()

### DIFF
--- a/aldryn_video/utils.py
+++ b/aldryn_video/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.utils.six import iteritems, text_type
 from django.utils.six.moves.urllib.parse import urlencode
 from django.utils.six.moves.urllib.parse import parse_qs, urlparse, urlunparse
 
@@ -42,10 +43,10 @@ def build_html_iframe(response, url_params=None, iframe_attrs=None):
 
         html['src'] = urlunparse(url_parts)
 
-        for key, value in iframe_attrs.iteritems():
+        for key, value in iteritems(iframe_attrs):
             if value:
                 html[key] = value
-    return unicode(html)
+    return text_type(html)
 
 
 def get_player_url(response):


### PR DESCRIPTION
`build_html_iframe()` uses `dict.iteritems()` and `unicode()`, which aren't part of Python 3.  This patch uses six to make the code work under Python 3.

Testcase:

```
from aldryn_video.models import OEmbedVideoPlugin
o = OEmbedVideoPlugin()
o.oembed_data = dict(provider_name='foo')
o.iframe_width = "800"
o.iframe_height = "600"
o.oembed_data['html'] = '<iframe src="http://www.w3schools.com" frameborder="1" name="foo"></iframe>'
o.html
```

Expected result:

```
'<iframe frameborder="1" height="600" name="foo" src="//www.w3schools.com" width="800"></iframe>'
```

(or equivalent Unicode literal with Python 2)
